### PR TITLE
ensure xerces include are in CPPFLAGS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 ## Process this file with automake to produce Makefile.in
 
 bin_PROGRAMS = crisprtools
-crisprtools_CXXFLAGS = @LIBCRISPR_CPPFLAGS@ -Werror -Wall -pedantic
+crisprtools_CXXFLAGS = @LIBCRISPR_CPPFLAGS@ @XERCES_CPPFLAGS@ -Werror -Wall -pedantic
 crisprtools_LDFLAGS = @LIBCRISPR_LDFLAGS@ @GV_LIBS@ @LIBCRISPR_LIBS@
 crisprtools_SOURCES = \
 	main.cpp \


### PR DESCRIPTION
Hello,

When building crisprtools, I discovered that the values from ./configure --with-xerces=/path/to/xerces were not being honored.  After investigating a bit, it seems that @XERCES_CPPFLAGS@ was omitted from the build CXXFLAGS.  I've proposed a modification which fixes this.

I hope this is helpful,
-Doug
